### PR TITLE
Back/next buttons below the list

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -23,6 +23,16 @@ Page {{ pagenumber }}
 </h1>
 
 {{ biglist }}
+
+<h1>
+{% if showprev %}
+<a href="/page/{{ showprev }}">back</a>
+{% endif %}
+Page {{ pagenumber }}
+{% if shownext %}
+<a href="/page/{{ shownext }}">next</a>
+{% endif %}
+</h1>
 {% endblock %}
 
 {% block sidebar %}


### PR DESCRIPTION
It's slightly annoying on smaller displays to have to scroll back to the top to go to the next page…
