### PR TITLE
Added FAQ entry about how to mark an issue as duplicate

### DIFF
--- a/python/templates/faq.html
+++ b/python/templates/faq.html
@@ -26,6 +26,11 @@ No. This site is purely for sharing your experiences with other developers.
 Please continue to use bugreport.apple.com to file problem reports with Apple.
 </p>
 
+<h2>How should I mark a problem as a duplicate?</h2>
+<p>
+The best way to mark an problem as a duplicate is to change its status to <code>Duplicate/&lt;radar_number&gt;</code>. This way the issue will be linked to its parent radar (given that it exists on OpenRadar).
+</p>
+
 <h2>Should I post the responses I receive from Apple?</h2>
 <p>
 Please be careful to not post any confidential information that you receive from Apple.


### PR DESCRIPTION
Since almost forever there seems to be an official way to mark a radar as a duplicate by changing its status to `Duplicate/<radar_number>` but very few people seem to know about it. So I thought creating an entry in the FAQ would help to spread the word.