### PR TITLE
Fix search/radarsby endpoints for [No Result] case

### DIFF
--- a/python/main.py
+++ b/python/main.py
@@ -540,12 +540,11 @@ class RadarsByUserAction(Handler):
   def get(self):
     username = self.request.get("user")
     user = users.User(username)
+    searchlist = ""
     if user:
       query = db.GqlQuery("select * from Radar where user = :1 order by number_intvalue desc", user)
       radars = query.fetch(100)
-      if len(radars) == 0:
-        searchlist = '<p>No matching results found.</p>'
-      else:
+      if len(radars) > 0:
         path = os.path.join(os.path.dirname(__file__), os.path.join('templates', 'biglist.html'))
         searchlist = template.render(path, {'radars':radars})
       self.respondWithTemplate('byuser.html', {"radarlist": searchlist})
@@ -557,15 +556,14 @@ class SearchAction(Handler):
     querystring = self.request.get("query")
     keywords = querystring.split(" ")
     keyword = keywords[0]
+    searchlist = ""
     try:
       query = Radar.all().search(keyword).order("-number")
       radars = query.fetch(100)
     except Exception:
-      self.respondWithTemplate('search.html', {"query":keyword, "searchlist":"<p>No matching results found.</p>"})
+      self.respondWithTemplate('search.html', {"query":keyword, "searchlist":searchlist})
       return
-    if len(radars) == 0:
-      searchlist = '<p>No matching results found.</p>'
-    else:
+    if len(radars) > 0:
       path = os.path.join(os.path.dirname(__file__), os.path.join('templates', 'biglist.html'))
       searchlist = template.render(path, {'radars':radars})
     self.respondWithTemplate('search.html', {"query":keyword, "searchlist": searchlist})

--- a/python/templates/byuser.html
+++ b/python/templates/byuser.html
@@ -3,7 +3,11 @@
 
 {% block content %}
 <h1>Radars posted by {{ username }}</h1>
+{% if radarlist|length != 0 %}
 {{ radarlist }}
+{% else %}
+<p>No matching results found.</p>
+{% endif %}
 {% endblock %}
 
 {% block sidebar %}

--- a/python/templates/search.html
+++ b/python/templates/search.html
@@ -7,7 +7,11 @@
 <h1>Search Results</h1>
 <h2>Query: {{ query|escape }}</h2>
 
+{% if searchlist|length != 0 %}
 {{ searchlist }}
+{% else %}
+<p>No matching results found.</p>
+{% endif %}
 
 <p style="border-top:solid thin; margin-top:40px">Didn't find what you wanted? Try this Google Custom Search.</p>
 <script src="http://www.gmodules.com/ig/ifr?url=http://www.google.com/coop/api/001299279272833145671/cse/kt5shgezrrk/gadget&amp;synd=open&amp;w=320&amp;h=75&amp;title=Open+Radar+Search&amp;border=%23ffffff%7C0px%2C1px+solid+%23998899%7C0px%2C1px+solid+%23aa99aa%7C0px%2C2px+solid+%23bbaabb%7C0px%2C2px+solid+%23ccbbcc&amp;output=js"></script>


### PR DESCRIPTION
Hey @timburks, @cvee,

PR to fix search endpoints when no results are returned; escaped HTML is being returned since Django autoescape is turned on in GAE. Have not modified the AUTHORS file since change is quite minor.

**Endpoints-affected:**
- [x] /radarsby
- [x] /search

**Changes:**
- [x] Remove HTML from main.py since webapp2 has autoescape enabled
- [x] Initialise 'searchlist' to an empty string
- [x] Test for the [No Result] case directly in the templates
- [x] Simplify conditionals in both handlers for the [No Result] case

**Tested-on:**
- [x] GAE Dev Server